### PR TITLE
fix: register find input focus command

### DIFF
--- a/packages/find-widget-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/find-widget-worker/src/parts/CommandMap/CommandMap.ts
@@ -4,6 +4,7 @@ import * as Create from '../Create/Create.ts'
 import * as Diff2 from '../Diff2/Diff2.ts'
 import * as Dispose from '../Dispose/Dispose.ts'
 import * as FindWidgetFocusCloseButton from '../FindWidgetFocusCloseButton/FindWidgetFocusCloseButton.ts'
+import * as FindWidgetFocusFind from '../FindWidgetFocusFind/FindWidgetFocusFind.ts'
 import * as FindWidgetFocusIndex from '../FindWidgetFocusIndex/FindWidgetFocusIndex.ts'
 import * as FindWidgetFocusReplace from '../FindWidgetFocusReplace/FindWidgetFocusReplace.ts'
 import * as FindWidgetFocusReplaceAllButton from '../FindWidgetFocusReplaceAllButton/FindWidgetFocusReplaceAllButton.ts'
@@ -43,6 +44,7 @@ export const commandMap = {
   'FindWidget.dispose': Dispose.dispose,
   'FindWidget.focusCloseButton': WrapCommand.wrapCommand(FindWidgetFocusCloseButton.focusCloseButton),
   'FindWidget.focusElement': WrapCommand.wrapCommand(focusElement),
+  'FindWidget.focusFind': WrapCommand.wrapCommand(FindWidgetFocusFind.focusFind),
   'FindWidget.focusFirst': WrapCommand.wrapCommand(FindWidgetFocusIndex.focusFirst),
   'FindWidget.focusIndex': WrapCommand.wrapCommand(FindWidgetFocusIndex.focusIndex),
   'FindWidget.focusLast': WrapCommand.wrapCommand(FindWidgetFocusIndex.focusLast),

--- a/packages/find-widget-worker/test/CommandMap.test.ts
+++ b/packages/find-widget-worker/test/CommandMap.test.ts
@@ -4,4 +4,5 @@ import * as CommandMap from '../src/parts/CommandMap/CommandMap.ts'
 test('commandMap', () => {
   const { commandMap } = CommandMap
   expect(typeof commandMap).toBe('object')
+  expect(commandMap['FindWidget.focusFind']).toBeDefined()
 })

--- a/packages/find-widget-worker/test/FindWidgetFocusFind.test.ts
+++ b/packages/find-widget-worker/test/FindWidgetFocusFind.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals'
+import type { FindWidgetState } from '../src/parts/FindWidgetState/FindWidgetState.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as FindWidgetFocusFind from '../src/parts/FindWidgetFocusFind/FindWidgetFocusFind.ts'
+import * as FocusKey from '../src/parts/FocusKey/FocusKey.ts'
+import * as FocusSource from '../src/parts/FocusSource/FocusSource.ts'
+
+test('focusFind - sets focus and source', () => {
+  const state: FindWidgetState = createDefaultState()
+  const result = FindWidgetFocusFind.focusFind(state)
+  expect(result.focus).toBe(FocusKey.FindWidget)
+  expect(result.focusSource).toBe(FocusSource.Script)
+})
+
+test('focusFind - returns same object if already focused', () => {
+  const state: FindWidgetState = {
+    ...createDefaultState(),
+    focus: FocusKey.FindWidget,
+  }
+  const result = FindWidgetFocusFind.focusFind(state)
+  expect(result).toBe(state)
+})


### PR DESCRIPTION
## Summary
- register the existing `FindWidget.focusFind` implementation in the worker command map
- add direct focus-state coverage and a command registration regression

This unblocks editor Ctrl/Cmd+F from refocusing an already-open Find widget without recreating or clearing it.

## Validation
- `npm test` (90 suites / 316 tests)
- `npm run type-check`
- `npm run lint`