### PR TITLE
fix: refocus find input on repeated request

### DIFF
--- a/packages/find-widget-worker/src/parts/Create/Create.ts
+++ b/packages/find-widget-worker/src/parts/Create/Create.ts
@@ -13,6 +13,7 @@ export const create = (uid: number, x: number, y: number, width: number, height:
     focus: 0,
     focused: false,
     focusSource: FocusSource.Unknown,
+    focusVersion: 0,
     height: 0,
     history: [],
     inputBorderWidth: 1,

--- a/packages/find-widget-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/find-widget-worker/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -12,6 +12,7 @@ export const createDefaultState = (): FindWidgetState => {
     focus: 0,
     focused: false,
     focusSource: FocusSource.Unknown,
+    focusVersion: 0,
     height: 0,
     history: [],
     inputBorderWidth: 1,

--- a/packages/find-widget-worker/src/parts/DiffFocus/DiffFocus.ts
+++ b/packages/find-widget-worker/src/parts/DiffFocus/DiffFocus.ts
@@ -1,5 +1,5 @@
 import type { FindWidgetState } from '../FindWidgetState/FindWidgetState.ts'
 
 export const isEqual = (oldState: FindWidgetState, newState: FindWidgetState): boolean => {
-  return oldState.focused === newState.focused && oldState.focus === newState.focus
+  return oldState.focused === newState.focused && oldState.focus === newState.focus && oldState.focusVersion === newState.focusVersion
 }

--- a/packages/find-widget-worker/src/parts/FindWidgetFocusFind/FindWidgetFocusFind.ts
+++ b/packages/find-widget-worker/src/parts/FindWidgetFocusFind/FindWidgetFocusFind.ts
@@ -1,7 +1,11 @@
+import { WhenExpression } from '@lvce-editor/constants'
 import type { FindWidgetState } from '../FindWidgetState/FindWidgetState.ts'
-import * as FocusKey from '../FocusKey/FocusKey.ts'
 import * as SetFindWidgetFocus from '../SetFindWidgetFocus/SetFindWidgetFocus.ts'
 
 export const focusFind = (state: FindWidgetState): FindWidgetState => {
-  return SetFindWidgetFocus.setFindWidgetFocus(state, FocusKey.FindWidget)
+  const newState = SetFindWidgetFocus.setFindWidgetFocus(state, WhenExpression.FocusSearchInput)
+  return {
+    ...newState,
+    focusVersion: state.focusVersion + 1,
+  }
 }

--- a/packages/find-widget-worker/src/parts/FindWidgetState/FindWidgetState.ts
+++ b/packages/find-widget-worker/src/parts/FindWidgetState/FindWidgetState.ts
@@ -9,6 +9,7 @@ export interface FindWidgetState {
   readonly focus: number
   readonly focused: boolean
   readonly focusSource: number
+  readonly focusVersion: number
   readonly height: number
   readonly history: readonly string[]
   readonly inputBorderWidth: number

--- a/packages/find-widget-worker/test/DiffFocus.test.ts
+++ b/packages/find-widget-worker/test/DiffFocus.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { isEqual } from '../src/parts/DiffFocus/DiffFocus.ts'
+
+test('isEqual - returns false when focus is requested again', () => {
+  const oldState = createDefaultState()
+  const newState = {
+    ...oldState,
+    focusVersion: oldState.focusVersion + 1,
+  }
+
+  expect(isEqual(oldState, newState)).toBe(false)
+})

--- a/packages/find-widget-worker/test/FindWidgetFocusFind.test.ts
+++ b/packages/find-widget-worker/test/FindWidgetFocusFind.test.ts
@@ -1,22 +1,25 @@
 import { expect, test } from '@jest/globals'
+import { WhenExpression } from '@lvce-editor/constants'
 import type { FindWidgetState } from '../src/parts/FindWidgetState/FindWidgetState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as FindWidgetFocusFind from '../src/parts/FindWidgetFocusFind/FindWidgetFocusFind.ts'
-import * as FocusKey from '../src/parts/FocusKey/FocusKey.ts'
 import * as FocusSource from '../src/parts/FocusSource/FocusSource.ts'
 
 test('focusFind - sets focus and source', () => {
   const state: FindWidgetState = createDefaultState()
   const result = FindWidgetFocusFind.focusFind(state)
-  expect(result.focus).toBe(FocusKey.FindWidget)
+  expect(result.focus).toBe(WhenExpression.FocusSearchInput)
   expect(result.focusSource).toBe(FocusSource.Script)
+  expect(result.focusVersion).toBe(1)
 })
 
-test('focusFind - returns same object if already focused', () => {
+test('focusFind - requests focus again if already focused', () => {
   const state: FindWidgetState = {
     ...createDefaultState(),
-    focus: FocusKey.FindWidget,
+    focus: WhenExpression.FocusSearchInput,
+    focusVersion: 2,
   }
   const result = FindWidgetFocusFind.focusFind(state)
-  expect(result).toBe(state)
+  expect(result.focus).toBe(WhenExpression.FocusSearchInput)
+  expect(result.focusVersion).toBe(3)
 })


### PR DESCRIPTION
## Summary
- target the actual search-input focus context from `FindWidget.focusFind`
- track explicit focus requests so repeated requests still emit a DOM focus command
- cover repeated focus diffing and command state with unit tests

## Validation
- 91 suites / 317 tests
- `npm run type-check`
- `npm run lint`