### PR TITLE
fix: navigate to previous match with shift enter

### DIFF
--- a/packages/find-widget-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/find-widget-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -10,6 +10,11 @@ export const getKeyBindings = (): readonly any[] => {
       when: WhenExpression.FocusFindWidget,
     },
     {
+      command: 'FindWidget.focusPrevious',
+      key: KeyModifier.Shift | KeyCode.Enter,
+      when: WhenExpression.FocusFindWidget,
+    },
+    {
       command: 'FindWidget.preventDefaultBrowserFind',
       key: KeyModifier.CtrlCmd | KeyCode.KeyF,
       when: WhenExpression.FocusFindWidget,

--- a/packages/find-widget-worker/test/GetKeyBindings.test.ts
+++ b/packages/find-widget-worker/test/GetKeyBindings.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { KeyCode, WhenExpression } from '@lvce-editor/constants'
+import { KeyCode, KeyModifier, WhenExpression } from '@lvce-editor/constants'
 import * as GetKeyBindings from '../src/parts/GetKeyBindings/GetKeyBindings.ts'
 
 test('getKeyBindings - returns an array of key bindings', () => {
@@ -13,6 +13,16 @@ test('getKeyBindings - Enter focuses the next match from the find input', () => 
   expect(result).toContainEqual({
     command: 'FindWidget.focusNext',
     key: KeyCode.Enter,
+    when: WhenExpression.FocusFindWidget,
+  })
+})
+
+test('getKeyBindings - Shift+Enter focuses the previous match from the find input', () => {
+  const result = GetKeyBindings.getKeyBindings()
+
+  expect(result).toContainEqual({
+    command: 'FindWidget.focusPrevious',
+    key: KeyModifier.Shift | KeyCode.Enter,
     when: WhenExpression.FocusFindWidget,
   })
 })


### PR DESCRIPTION
Adds the standard Shift+Enter find-widget shortcut for navigating to the previous match while keeping plain Enter mapped to the next match.

Includes keybinding regression coverage. The full browser-path regression is included in the corresponding editor-worker change.