### PR TITLE
fix: close find widget with escape

### DIFF
--- a/packages/find-widget-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/find-widget-worker/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -5,6 +5,11 @@ import { WhenExpression } from '@lvce-editor/constants'
 export const getKeyBindings = (): readonly any[] => {
   return [
     {
+      command: 'FindWidget.close',
+      key: KeyCode.Escape,
+      when: WhenExpression.FocusFindWidget,
+    },
+    {
       command: 'FindWidget.focusNext',
       key: KeyCode.Enter,
       when: WhenExpression.FocusFindWidget,

--- a/packages/find-widget-worker/test/GetKeyBindings.test.ts
+++ b/packages/find-widget-worker/test/GetKeyBindings.test.ts
@@ -7,6 +7,16 @@ test('getKeyBindings - returns an array of key bindings', () => {
   expect(result).toBeDefined()
 })
 
+test('getKeyBindings - Escape closes the find widget', () => {
+  const result = GetKeyBindings.getKeyBindings()
+
+  expect(result).toContainEqual({
+    command: 'FindWidget.close',
+    key: KeyCode.Escape,
+    when: WhenExpression.FocusFindWidget,
+  })
+})
+
 test('getKeyBindings - Enter focuses the next match from the find input', () => {
   const result = GetKeyBindings.getKeyBindings()
 


### PR DESCRIPTION
Registers Escape as the find-widget close shortcut while the find input is focused, with keybinding regression coverage.