### PR TITLE
fix: expose invalid regex errors accessibly

### DIFF
--- a/packages/e2e/src/find-widget-regular-expression-invalid.ts
+++ b/packages/e2e/src/find-widget-regular-expression-invalid.ts
@@ -24,8 +24,8 @@ content 2`,
   await expect(matchCaseCheckBox).toHaveAttribute(`aria-checked`, 'true')
   const findWidgetMatchCount = Locator(`.FindWidgetMatchCount`)
   await expect(findWidgetMatchCount).toBeVisible()
-  await expect(findWidgetMatchCount).toHaveText('No Results')
+  await expect(findWidgetMatchCount).toContainText('Invalid regular expression')
+  await expect(findWidgetMatchCount).toHaveAttribute('role', 'alert')
   const searchField = Locator(`.FindWidget .SearchField`)
   await expect(searchField).toHaveClass('SearchFieldError')
-  // TODO error message should be displayed below find input
 }

--- a/packages/find-widget-worker/src/parts/GetFindWidgetFindVirtualDom/GetFindWidgetFindVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetFindWidgetFindVirtualDom/GetFindWidgetFindVirtualDom.ts
@@ -45,13 +45,15 @@ export const getFindWidgetFindVirtualDom = (
       DomEventListenerFunctions.HandleFocus,
       extraClassName,
       inputFocused,
+      hasError ? 'FindWidgetInputError' : '',
+      hasError ? 'true' : '',
     ),
     {
       childCount: 1 + buttons.length,
       className: 'FindWidgetActions',
       type: VirtualDomElements.Div,
     },
-    ...getMatchCountVirtualDom(matchCountText, matchCount, hasValue),
+    ...getMatchCountVirtualDom(matchCountText, matchCount, hasValue, hasError),
     ...buttons.flatMap(GetIconButtonVirtualDom.getIconButtonVirtualDom),
   ]
 }

--- a/packages/find-widget-worker/src/parts/GetMatchCountVirtualDom/GetMatchCountVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetMatchCountVirtualDom/GetMatchCountVirtualDom.ts
@@ -1,13 +1,20 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import { AriaRoles } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as GetFindMatchCountClassName from '../GetFindMatchCountClassName/GetFindMatchCountClassName.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
-export const getMatchCountVirtualDom = (matchCountText: string, matchCount: number, hasValue: boolean): readonly VirtualDomNode[] => {
+export const getMatchCountVirtualDom = (
+  matchCountText: string,
+  matchCount: number,
+  hasValue: boolean,
+  hasError = false,
+): readonly VirtualDomNode[] => {
   return [
     {
       childCount: 1,
       className: GetFindMatchCountClassName.getFindMatchCountClassName(matchCount, hasValue),
+      ...(hasError && { id: 'FindWidgetInputError', role: AriaRoles.Alert }),
       type: VirtualDomElements.Div,
     },
     text(matchCountText),

--- a/packages/find-widget-worker/src/parts/GetSearchFieldVirtualDom/GetSearchFieldVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetSearchFieldVirtualDom/GetSearchFieldVirtualDom.ts
@@ -14,6 +14,8 @@ export const getSearchFieldVirtualDom = (
   onFocus: string | number,
   extraClassName: string,
   autofocus = false,
+  ariaDescribedBy = '',
+  ariaInvalid = '',
 ): readonly VirtualDomNode[] => {
   if (outsideButtons.length > 0) {
     throw new Error('outsideButtons are deprecated')
@@ -38,6 +40,8 @@ export const getSearchFieldVirtualDom = (
       spellcheck: false,
       type: VirtualDomElements.TextArea,
       ...(autofocus && { autofocus: true }),
+      ...(ariaDescribedBy && { ariaDescribedBy }),
+      ...(ariaInvalid && { ariaInvalid }),
     },
     {
       childCount: insideButtons.length,

--- a/packages/find-widget-worker/src/parts/RenderContent/RenderContent.ts
+++ b/packages/find-widget-worker/src/parts/RenderContent/RenderContent.ts
@@ -9,7 +9,7 @@ import * as RenderMethod from '../RenderMethod/RenderMethod.ts'
 export const renderContent = (oldState: FindWidgetState, newState: FindWidgetState): readonly any[] => {
   const { focus, inputErrorMessage, matchCase, matchCount, matchWholeWord, preserveCase, replaceExpanded, uid, useRegularExpression, value } =
     newState
-  const matchCountText = GetMatchCountText.getMatchCountText(newState.matchIndex, newState.matchCount)
+  const matchCountText = inputErrorMessage || GetMatchCountText.getMatchCountText(newState.matchIndex, newState.matchCount)
   const { findButtonsEnabled, replaceButtonsEnabled } = GetFindWidgetButtonsEnabled.getFindWidgetButtonsEnabled(matchCount, value)
   const { findButtons, findFieldButtons, replaceButtons, replaceFieldButtons } = GetFindWidgetButtons.getFindWidgetButtons(
     findButtonsEnabled,

--- a/packages/find-widget-worker/test/GetFindWidgetFindVirtualDom.test.ts
+++ b/packages/find-widget-worker/test/GetFindWidgetFindVirtualDom.test.ts
@@ -329,6 +329,8 @@ test('getFindWidgetFindVirtualDom returns correct virtual dom elements with erro
     type: VirtualDomElements.Div,
   })
   expect(result[2]).toEqual({
+    ariaDescribedBy: 'FindWidgetInputError',
+    ariaInvalid: 'true',
     autocapitalize: 'off',
     autocorrect: 'off',
     childCount: 0,
@@ -339,5 +341,12 @@ test('getFindWidgetFindVirtualDom returns correct virtual dom elements with erro
     placeholder: FindStrings.find(),
     spellcheck: false,
     type: VirtualDomElements.TextArea,
+  })
+  expect(result).toContainEqual({
+    childCount: 1,
+    className: `${ClassNames.FindWidgetMatchCount} ${ClassNames.FindWidgetMatchCountEmpty}`,
+    id: 'FindWidgetInputError',
+    role: 'alert',
+    type: VirtualDomElements.Div,
   })
 })


### PR DESCRIPTION
## Summary
- show the regular-expression parser error instead of the misleading `No Results` text
- expose the error as an ARIA alert and associate the find input with it
- mark the input invalid in the virtual DOM
- add unit coverage and enable the browser regression test for invalid regex feedback

Depends on the now-released `@lvce-editor/virtual-dom` v11.7.2 mapping added in lvce-editor/virtual-dom#520.

## Verification
- `npm test` (319 passed)
- `npm run lint`
- `npm run type-check`
- `npm run build`
- full e2e suite (54 passed, 27 skipped, 0 failed)