### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     ignores: ['**/server/**', '**/e2e/**', '**/memory/**'],
@@ -14,6 +15,23 @@ export default [
       '@typescript-eslint/prefer-readonly-parameter-types': 'off',
       'no-useless-escape': 'off',
       'no-restricted-syntax': 'off',
+    },
+  },
+  {
+    files: ['packages/find-widget-worker/src/parts/**/*.ts'],
+    ignores: ['packages/find-widget-worker/src/parts/**/*VirtualDom/**/*.ts'],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: ['packages/find-widget-worker/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
+      'virtual-dom/valid-child-count': 'off',
     },
   },
 ]

--- a/packages/find-widget-worker/src/parts/GetIconVirtualDom/GetIconVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetIconVirtualDom/GetIconVirtualDom.ts
@@ -2,11 +2,12 @@ import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import { AriaRoles } from '@lvce-editor/virtual-dom-worker'
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
 export const getIconVirtualDom = (icon: string, type = VirtualDomElements.Div): VirtualDomNode => {
   return {
     childCount: 0,
-    className: `${ClassNames.MaskIcon} MaskIcon${icon}`,
+    className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, `MaskIcon${icon}`),
     role: AriaRoles.None,
     type,
   }

--- a/packages/find-widget-worker/src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetSearchFieldButtonVirtualDom/GetSearchFieldButtonVirtualDom.ts
@@ -4,6 +4,7 @@ import { AriaRoles } from '@lvce-editor/virtual-dom-worker'
 import type { ISearchFieldButton } from '../ISearchFieldButton/ISearchFieldButton.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 const checkedClassName = MergeClassNames.mergeClassNames(ClassNames.SearchFieldButton, ClassNames.SearchFieldButtonChecked)
 const unCheckedClassName = ClassNames.SearchFieldButton
@@ -18,7 +19,7 @@ export const getSearchFieldButtonVirtualDom = (button: ISearchFieldButton): read
       name,
       onClick,
       role: AriaRoles.CheckBox,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       title,
       type: VirtualDomElements.Button,
     },

--- a/packages/find-widget-worker/src/parts/TabIndex/TabIndex.ts
+++ b/packages/find-widget-worker/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0


### PR DESCRIPTION
## Summary
- enable the recommended virtual DOM ESLint configuration
- use shared class-name merging and a named tab-index constant
- scope reducer-state and raw expected-DOM exceptions

## Validation
- npm run lint
- npm run build
- npm run type-check
- npm test
- npm run measure