### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^16.3.0",
+        "@lvce-editor/eslint-config": "^17.0.3",
         "eslint": "^10.7.0",
         "lerna": "^8.2.4",
         "prettier": "^3.8.1",
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.3.0.tgz",
-      "integrity": "sha512-b9dA9AKt56w1LeAXhQssew3EXxSj1zB88UGAXVGsdx5MdOSz7Him8Ye92z2N0FPeUQceFm31ZKWaIVlr0RqYRA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
+      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1696,14 +1696,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.3.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.3.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.3.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.3.0",
-        "@lvce-editor/eslint-plugin-regex": "16.3.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.3.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.3.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.3.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
+        "@lvce-editor/eslint-plugin-regex": "17.0.3",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1718,9 +1718,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.3.0.tgz",
-      "integrity": "sha512-y0IwVWIbQ/XqDBMn4e/P6XgPDjYC+JtE/xJEiNTPXVBkTk68cXqh7ZjOSDhuFd0hV6kcoDcmkgDmFkFRBfoh+Q==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
+      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1728,16 +1728,16 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.3.0.tgz",
-      "integrity": "sha512-oowag6tMX17ld1mWJkvyNvSqBSfaJ6Ooa5cX3tRkPMrXlsiJBox8lHjyeJWrv4kVFMiRwAUPo9ZMNlk3nW2K3A==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
+      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.3.0.tgz",
-      "integrity": "sha512-doTjA1TmA1P4DYMQxIcTMCWsWCwy+7Sn7AqB7lanj6Z+ar9krxAr5nILKYmbv/RIdsomqA3AoCO/ZVyVqfJkKA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
+      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.3.0.tgz",
-      "integrity": "sha512-ikZvK3evru13petroIKIc5upQZDVsKO/4OALBgAdkWzXGHYatw7AKe74Z5XP0eqMQhTMQCfPLtVZ2Z3w7QOFVQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
+      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1769,23 +1769,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.3.0.tgz",
-      "integrity": "sha512-IJtqreVVMHZkQnu4wsu497karsQZMogSLj2zKUj2fhRB+c2eorQTgTDMdrcKr/b4D42Ws/nV8Z+GdfaNGyHP4A==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
+      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.3.0.tgz",
-      "integrity": "sha512-NTLmeUuNeTRHxHk/DzUEDjse18ms6pxoQnXHi0qJopPEBQmo74FoxNalsGG0lbjUeZ3n22WICJaxqwbRSLpbgg==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
+      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.3.0.tgz",
-      "integrity": "sha512-VeA1KGHGhwmtyvOLgQZTllUXF1aShAW7h+biYWf1ccri8jzAV5gK5br9UvNvihHK6lrW6kk+GblLhwysUYzxvQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
+      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1793,9 +1793,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.3.0.tgz",
-      "integrity": "sha512-c4U5J8YOCk6v4xFH6JsfzK3wBKRlQhdgKOOFj5VlGGd7hkdSjaFcbqu6EwqAZHyFpuLvMO+dn0pb4RkqECzvQQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
+      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^16.3.0",
+    "@lvce-editor/eslint-config": "^17.0.3",
     "eslint": "^10.7.0",
     "lerna": "^8.2.4",
     "prettier": "^3.8.1",

--- a/packages/find-widget-worker/src/parts/GetFindWidgetFindVirtualDom/GetFindWidgetFindVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetFindWidgetFindVirtualDom/GetFindWidgetFindVirtualDom.ts
@@ -10,6 +10,12 @@ import { getMatchCountVirtualDom } from '../GetMatchCountVirtualDom/GetMatchCoun
 import * as GetSearchFieldVirtualDom from '../GetSearchFieldVirtualDom/GetSearchFieldVirtualDom.ts'
 import * as InputName from '../InputName/InputName.ts'
 
+const findWidgetFindNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.FindWidgetFind,
+  type: VirtualDomElements.Div,
+}
+
 const getExtraClassName = (hasError: boolean, inputFocused: boolean): string => {
   if (hasError) {
     return ClassNames.SearchFieldError
@@ -31,11 +37,7 @@ export const getFindWidgetFindVirtualDom = (
 ): readonly VirtualDomNode[] => {
   const extraClassName = getExtraClassName(hasError, inputFocused)
   return [
-    {
-      childCount: 2,
-      className: ClassNames.FindWidgetFind,
-      type: VirtualDomElements.Div,
-    },
+    findWidgetFindNode,
     ...GetSearchFieldVirtualDom.getSearchFieldVirtualDom(
       InputName.SearchValue,
       FindStrings.find(),

--- a/packages/find-widget-worker/src/parts/GetIconButtonVirtualDom/GetIconButtonVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetIconButtonVirtualDom/GetIconButtonVirtualDom.ts
@@ -3,13 +3,11 @@ import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { FindWidgetButton } from '../FindWidgetButton/FindWidgetButton.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetIconVirtualDom from '../GetIconVirtualDom/GetIconVirtualDom.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
 export const getIconButtonVirtualDom = (iconButton: FindWidgetButton): readonly VirtualDomNode[] => {
   const { disabled, icon, label, name, onClick } = iconButton
-  let className = ClassNames.IconButton
-  if (disabled) {
-    className += ' ' + ClassNames.IconButtonDisabled
-  }
+  const className = MergeClassNames.mergeClassNames(ClassNames.IconButton, disabled ? ClassNames.IconButtonDisabled : '')
   return [
     {
       ariaLabel: label,

--- a/packages/find-widget-worker/src/parts/GetResizerVirtualDom/GetResizerVirtualDom.ts
+++ b/packages/find-widget-worker/src/parts/GetResizerVirtualDom/GetResizerVirtualDom.ts
@@ -3,18 +3,19 @@ import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 
+const resizerNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.Resizer,
+  onPointerDown: DomEventListenerFunctions.HandleResizerPointerDown,
+  type: VirtualDomElements.Div,
+}
+
+const resizerHighlightNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ResizerHighlight,
+  type: VirtualDomElements.Div,
+}
+
 export const getResizerVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: ClassNames.Resizer,
-      onPointerDown: DomEventListenerFunctions.HandleResizerPointerDown,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ResizerHighlight,
-      type: VirtualDomElements.Div,
-    },
-  ]
+  return [resizerNode, resizerHighlightNode]
 }

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 440_000
+export const threshold = 445_000
 
 export const instantiations = 1500
 


### PR DESCRIPTION
Update the shared ESLint config, hoist static find-widget virtual DOM nodes, and use the class-name merge helper required by the latest lint rules.