### PR TITLE
test: investigate flaky e2e overlay

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        os: [windows-2025]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3004,49 +3004,44 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-12.1.0.tgz",
-      "integrity": "sha512-JiLhAFIkmkXy5lpHzOS0uZYwYV0asAk5VwPqPtavY4C7TBi/J7ZEVaJgP/IkOAkt0SD04yYtYXKHNUOdfdSMLQ==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.14.0.tgz",
+      "integrity": "sha512-QcWic9gv3ObNPgZZycVMf1CCcAv6/VmlNoNpof7uMdgxuKDTiP6K0oh50vV0xuOCsckaxSMosDV3Zg/vhWHD/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "12.1.0",
-        "@lvce-editor/test-worker": "^11.0.0"
+        "@lvce-editor/test-with-playwright-worker": "22.14.0",
+        "@lvce-editor/test-worker": "^17.8.0"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-12.1.0.tgz",
-      "integrity": "sha512-1d2ZXS7csAhXvoL+U+C9CJU56ZHsp+ftVwdTLQSGleUogDa0PQnUs5baKcoKz9ijyfqqX/2RdwTUmZ/80ez6rg==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.14.0.tgz",
+      "integrity": "sha512-43KccaZQDBzP6oHZu1DvE1TNiSiyL0Vt1DilBU01i/WlWG+qj1JvYIhRxNjAUji+xNFRN9rLs8OhzacTzXu5PA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "1.57.0"
+        "@playwright/test": "1.61.1",
+        "get-port": "^7.2.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "v8-to-istanbul": "^9.3.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-11.17.0.tgz",
-      "integrity": "sha512-xg501ukF48YkEd0YlYvxpnG+UjkzU/5Kwnzg50XEdKkC97zDCZIOcOATqX6WrokDJPxvtY1fVI9ECKqdirF1QA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/constants": "^3.5.0"
-      }
-    },
-    "node_modules/@lvce-editor/test-worker/node_modules/@lvce-editor/constants": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-3.7.0.tgz",
-      "integrity": "sha512-NTxt0cZlacI63ZryyoMFh1Nw717jyWpTIqnoaK7ssNBDjAWuEmIdNTcJq2ZyAtGkcJReuq1XHzbjAE5o44O0ow==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.8.0.tgz",
+      "integrity": "sha512-u1XyQG/7QsVq2xaEmwGOTgYtysOjpweWNsi/YNboyT/Imq7sWjwZT4g+hGr5PYMWzNgMlqOg+YfrDrgUQWlAFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3170,13 +3165,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7005,6 +7000,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -9896,13 +9904,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9915,9 +9923,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13191,7 +13199,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^12.1.0"
+        "@lvce-editor/test-with-playwright": "^22.14.0"
       }
     },
     "packages/find-widget-worker": {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/test-with-playwright": "^12.1.0"
+    "@lvce-editor/test-with-playwright": "^22.14.0"
   }
 }

--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 450_000
+export const threshold = 460_000
 
 export const instantiations = 1500
 


### PR DESCRIPTION
## Problem

The Windows job in run 30218846334 failed after 18 E2E tests because `#TestOverlay` disappeared and the harness timed out waiting for it. Ubuntu and macOS passed.

## Candidate

- update `@lvce-editor/test-with-playwright` from 12.1.0 to 22.14.0
- keep the application/server stack unchanged
- adjust the memory threshold from 450,000 to 460,000 bytes for the newer bundled Chromium (local reading: 455,420 bytes)
- run the complete Windows workflow 20 isolated times

## Validation

Local:
- build and static build passed
- 92 unit suites / 323 tests passed
- type-check and lint passed
- E2E: 52 passed, 29 skipped, including the original overlay path
- memory: 455,420 / 460,000 bytes

CI:
- run 30219869930 passed 20/20 isolated Windows jobs
- every job completed build, static build, unit tests, type-check, lint, E2E, and memory
- the `#TestOverlay` disappearance did not recur

Diagnostic-only PR. Closing unmerged; the proven dependency and threshold changes will be integrated into the production PR.