### PR TITLE
Fix find widget replacement actions

### DIFF
--- a/packages/find-widget-worker/src/parts/DiffFocusContext/DiffFocusContext.ts
+++ b/packages/find-widget-worker/src/parts/DiffFocusContext/DiffFocusContext.ts
@@ -1,5 +1,5 @@
 import type { FindWidgetState } from '../FindWidgetState/FindWidgetState.ts'
 
 export const isEqual = (oldState: FindWidgetState, newState: FindWidgetState): boolean => {
-  return oldState.focused === newState.focused
+  return oldState.focused === newState.focused && oldState.focus === newState.focus
 }

--- a/packages/find-widget-worker/src/parts/GetEdits/GetEdits.ts
+++ b/packages/find-widget-worker/src/parts/GetEdits/GetEdits.ts
@@ -75,5 +75,8 @@ export const getEdits = (
       startOffset,
     })
   }
+  if (replaceAll) {
+    edits.reverse()
+  }
   return edits
 }

--- a/packages/find-widget-worker/src/parts/RenderFocusContext/RenderFocusContext.ts
+++ b/packages/find-widget-worker/src/parts/RenderFocusContext/RenderFocusContext.ts
@@ -1,7 +1,14 @@
-import { ViewletCommand } from '@lvce-editor/constants'
+import { ViewletCommand, WhenExpression as SearchWhenExpression } from '@lvce-editor/constants'
 import type { FindWidgetState } from '../FindWidgetState/FindWidgetState.ts'
 import * as WhenExpression from '../WhenExpression/WhenExpression.ts'
 
 export const renderFocusContext = (oldState: FindWidgetState, newState: FindWidgetState): readonly any[] => {
-  return [/* method */ ViewletCommand.SetFocusContext, WhenExpression.FocusFindWidget]
+  const { focus } = newState
+  if (focus === SearchWhenExpression.FocusSearchReplaceInput) {
+    return [/* method */ ViewletCommand.SetFocusContext, SearchWhenExpression.FocusFindWidgetReplace]
+  }
+  if (focus === SearchWhenExpression.FocusSearchInput || !focus) {
+    return [/* method */ ViewletCommand.SetFocusContext, WhenExpression.FocusFindWidget]
+  }
+  return [/* method */ ViewletCommand.SetFocusContext, focus]
 }

--- a/packages/find-widget-worker/test/DiffFocusContext.test.ts
+++ b/packages/find-widget-worker/test/DiffFocusContext.test.ts
@@ -16,3 +16,10 @@ test('isEqual returns false when focused states are different', () => {
   const result: boolean = isEqual(state1, state2)
   expect(result).toBe(false)
 })
+
+test('isEqual returns false when focus contexts are different', () => {
+  const state1: FindWidgetState = createDefaultState()
+  const state2: FindWidgetState = { ...createDefaultState(), focus: 43 }
+  const result: boolean = isEqual(state1, state2)
+  expect(result).toBe(false)
+})

--- a/packages/find-widget-worker/test/GetEdits.test.ts
+++ b/packages/find-widget-worker/test/GetEdits.test.ts
@@ -32,10 +32,10 @@ test('getEdits - replace all occurrences', () => {
   const edits = getEdits(matches, value, replacement, 0, true, lines)
   expect(edits).toEqual([
     {
-      endOffset: 3,
+      endOffset: 19,
       inserted: 'baz',
       origin: 'find-widget.replace',
-      startOffset: 0,
+      startOffset: 16,
     },
     {
       endOffset: 11,
@@ -44,10 +44,10 @@ test('getEdits - replace all occurrences', () => {
       startOffset: 8,
     },
     {
-      endOffset: 19,
+      endOffset: 3,
       inserted: 'baz',
       origin: 'find-widget.replace',
-      startOffset: 16,
+      startOffset: 0,
     },
   ])
 })

--- a/packages/find-widget-worker/test/GetEditsPreserveCase.test.ts
+++ b/packages/find-widget-worker/test/GetEditsPreserveCase.test.ts
@@ -58,8 +58,8 @@ test('getEdits - preserve case with replaceAll', () => {
   const edits = getEdits(matches, value, replacement, 0, true, lines, true)
 
   expect(edits).toHaveLength(2)
-  expect(edits[0].inserted).toBe('WORLD')
-  expect(edits[1].inserted).toBe('world')
+  expect(edits[0].inserted).toBe('world')
+  expect(edits[1].inserted).toBe('WORLD')
 })
 
 test('getEdits - preserve case with mixed case patterns', () => {
@@ -71,7 +71,7 @@ test('getEdits - preserve case with mixed case patterns', () => {
   const edits = getEdits(matches, value, replacement, 0, true, lines, true)
 
   expect(edits).toHaveLength(3)
-  expect(edits[0].inserted).toBe('WORLD')
+  expect(edits[0].inserted).toBe('world')
   expect(edits[1].inserted).toBe('World')
-  expect(edits[2].inserted).toBe('world')
+  expect(edits[2].inserted).toBe('WORLD')
 })

--- a/packages/find-widget-worker/test/RenderFocusContext.test.ts
+++ b/packages/find-widget-worker/test/RenderFocusContext.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { ViewletCommand } from '@lvce-editor/constants'
+import { ViewletCommand, WhenExpression as SearchWhenExpression } from '@lvce-editor/constants'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.js'
 import { renderFocusContext } from '../src/parts/RenderFocusContext/RenderFocusContext.js'
 import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.js'
@@ -9,4 +9,24 @@ test('renderFocusContext', () => {
   const newState = createDefaultState()
   const result = renderFocusContext(oldState, newState)
   expect(result).toEqual([ViewletCommand.SetFocusContext, WhenExpression.FocusFindWidget])
+})
+
+test('renderFocusContext - replace input', () => {
+  const oldState = createDefaultState()
+  const newState = {
+    ...createDefaultState(),
+    focus: SearchWhenExpression.FocusSearchReplaceInput,
+  }
+  const result = renderFocusContext(oldState, newState)
+  expect(result).toEqual([ViewletCommand.SetFocusContext, SearchWhenExpression.FocusFindWidgetReplace])
+})
+
+test('renderFocusContext - replace button', () => {
+  const oldState = createDefaultState()
+  const newState = {
+    ...createDefaultState(),
+    focus: SearchWhenExpression.FocusFindWidgetReplaceButton,
+  }
+  const result = renderFocusContext(oldState, newState)
+  expect(result).toEqual([ViewletCommand.SetFocusContext, SearchWhenExpression.FocusFindWidgetReplaceButton])
 })

--- a/packages/find-widget-worker/test/ReplaceAll.test.ts
+++ b/packages/find-widget-worker/test/ReplaceAll.test.ts
@@ -42,10 +42,10 @@ test('replaceAll - applies edits for all matches', async () => {
     1,
     [
       {
-        endOffset: 3,
+        endOffset: 19,
         inserted: 'baz',
         origin: 'find-widget.replace',
-        startOffset: 0,
+        startOffset: 16,
       },
       {
         endOffset: 11,
@@ -54,10 +54,10 @@ test('replaceAll - applies edits for all matches', async () => {
         startOffset: 8,
       },
       {
-        endOffset: 19,
+        endOffset: 3,
         inserted: 'baz',
         origin: 'find-widget.replace',
-        startOffset: 16,
+        startOffset: 0,
       },
     ],
   ])


### PR DESCRIPTION
## Summary

- emit specific focus contexts for find-widget controls
- diff focus-context changes so keyboard shortcuts follow the active control
- apply replace-all edits from the end of the document to avoid shifting later offsets

## Verification

- npm test (326 tests)
- npm run type-check
- npm run lint
- npm run build
- source-app checks for Replace, Replace All, Enter, and Ctrl+Alt+Enter