### PR TITLE
feature: enforce 97% branch coverage

### DIFF
--- a/packages/find-widget-worker/package.json
+++ b/packages/find-widget-worker/package.json
@@ -36,7 +36,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "branches": 90,
+        "branches": 97,
         "functions": 90,
         "lines": 90
       }

--- a/packages/find-widget-worker/test/ApplyRegexReplacement.test.ts
+++ b/packages/find-widget-worker/test/ApplyRegexReplacement.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { applyRegexReplacement } from '../src/parts/ApplyRegexReplacement/ApplyRegexReplacement.ts'
+
+test('returns the replacement when the regular expression does not match', () => {
+  expect(applyRegexReplacement('hello', /(world)/g, '$1')).toBe('$1')
+})
+
+test('replaces an unmatched optional capture group with an empty string', () => {
+  expect(applyRegexReplacement('b', /(a)?b/g, '[$1]')).toBe('[]')
+})
+
+test('preserves a reference to a capture group that does not exist', () => {
+  expect(applyRegexReplacement('hello', /(hello)/g, '$2')).toBe('$2')
+})

--- a/packages/find-widget-worker/test/Diff2.test.ts
+++ b/packages/find-widget-worker/test/Diff2.test.ts
@@ -11,3 +11,17 @@ test('diff2 should return diff result for state', () => {
   const result: readonly number[] = Diff2.diff2(uid)
   expect(Array.isArray(result)).toBe(true)
 })
+
+test('diffInstance should return an empty result for an unknown instance', () => {
+  expect(Diff2.diffInstance('unknown')).toEqual([])
+})
+
+test('diffInstance should return the diff result for a registered instance', () => {
+  const uid = 2
+  const instanceId = 'editor:diff:find'
+  const state = CreateDefaultState.createDefaultState()
+  FindWidgetStates.set(uid, state, state)
+  FindWidgetStates.registerInstance(instanceId, uid)
+
+  expect(Diff2.diffInstance(instanceId)).toEqual([])
+})

--- a/packages/find-widget-worker/test/FindWidgetRefresh.test.ts
+++ b/packages/find-widget-worker/test/FindWidgetRefresh.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { refresh } from '../src/parts/FindWidgetRefresh/FindWidgetRefresh.ts'
+
+test('refresh uses the current value and user input source by default', () => {
+  const state = {
+    ...createDefaultState(),
+    lines: ['hello world'],
+    value: 'hello',
+  }
+
+  const result = refresh(state)
+
+  expect(result.value).toBe('hello')
+  expect(result.matchCount).toBe(1)
+})

--- a/packages/find-widget-worker/test/FindWidgetRefreshWithEditor.test.ts
+++ b/packages/find-widget-worker/test/FindWidgetRefreshWithEditor.test.ts
@@ -36,3 +36,16 @@ test('refresh with case insensitive matching', () => {
   expect(result.matchIndex).toBe(0)
   expect(result.value).toBe('hello')
 })
+
+test('refresh with invalid regular expression', () => {
+  const state: FindWidgetState = {
+    ...createDefaultState(),
+    lines: ['hello'],
+    useRegularExpression: true,
+  }
+
+  const result = refresh(state, '[', InputSource.User)
+
+  expect(result.inputErrorMessage).not.toBe('')
+  expect(result.value).toBe('')
+})

--- a/packages/find-widget-worker/test/FindWidgetStates.test.ts
+++ b/packages/find-widget-worker/test/FindWidgetStates.test.ts
@@ -20,3 +20,99 @@ test('ignores a command completion after its instance is disposed', async () => 
 
   expect(FindWidgetStates.get(31)).toBeUndefined()
 })
+
+test('registerInstance disposes the state previously registered for the instance', () => {
+  Create.createInstance('editor:find:reused', 32, 0, 0, 800, 600, 1)
+  const state = Create.createInstance('editor:find:reused', 33, 0, 0, 800, 600, 1)
+
+  expect(FindWidgetStates.get(32)).toBeUndefined()
+  expect(FindWidgetStates.get(33).newState).toBe(state)
+  expect(FindWidgetStates.resolveUid('editor:find:reused')).toBe(33)
+})
+
+test('wrapInstanceCommand ignores an unknown instance', async () => {
+  let called = false
+  const command = FindWidgetStates.wrapInstanceCommand((state) => {
+    called = true
+    return state
+  })
+
+  await command('unknown')
+
+  expect(called).toBe(false)
+})
+
+test('wrapInstanceCommand ignores an instance without state', async () => {
+  FindWidgetStates.registerInstance('editor:find:missing-state', 34)
+  let called = false
+  const command = FindWidgetStates.wrapInstanceCommand((state) => {
+    called = true
+    return state
+  })
+
+  await command('editor:find:missing-state')
+
+  expect(called).toBe(false)
+})
+
+test('wrapInstanceCommand ignores an unchanged state', async () => {
+  const state = Create.createInstance('editor:find:unchanged', 35, 0, 0, 800, 600, 1)
+  const command = FindWidgetStates.wrapInstanceCommand(() => state)
+
+  await command(state.instanceId!)
+
+  expect(FindWidgetStates.get(35).newState).toBe(state)
+})
+
+test('wrapInstanceCommand updates the registered state', async () => {
+  const state = Create.createInstance('editor:find:update', 36, 0, 0, 800, 600, 1)
+  const command = FindWidgetStates.wrapInstanceCommand((current) => ({
+    ...current,
+    value: 'updated',
+  }))
+
+  await command(state.instanceId!)
+
+  expect(FindWidgetStates.get(36).newState.value).toBe('updated')
+})
+
+test('wrapInstanceCommand ignores completion after the instance is reassigned', async () => {
+  const state = Create.createInstance('editor:find:reassigned', 37, 0, 0, 800, 600, 1)
+  const { promise, resolve } = Promise.withResolvers<void>()
+  const command = FindWidgetStates.wrapInstanceCommand(async (current) => {
+    await promise
+    return {
+      ...current,
+      value: 'stale',
+    }
+  })
+
+  const running = command(state.instanceId!)
+  Create.createInstance(state.instanceId!, 38, 0, 0, 800, 600, 1)
+  resolve()
+  await running
+
+  expect(FindWidgetStates.get(38).newState.value).toBe('')
+})
+
+test('wrapInstanceCommand ignores completion when the registered state is missing', async () => {
+  const instanceId = 'editor:find:disposed-state'
+  const state = Create.create(39, 0, 0, 800, 600, 1)
+  FindWidgetStates.registerInstance(instanceId, 39)
+  const { promise, resolve } = Promise.withResolvers<void>()
+  const command = FindWidgetStates.wrapInstanceCommand(async (current) => {
+    await promise
+    return {
+      ...current,
+      value: 'stale',
+    }
+  })
+
+  const running = command(instanceId)
+  FindWidgetStates.dispose(39)
+  resolve()
+  await running
+
+  expect(FindWidgetStates.get(39)).toBeUndefined()
+  expect(state.value).toBe('')
+})

--- a/packages/find-widget-worker/test/GetMatchCountVirtualDom.test.ts
+++ b/packages/find-widget-worker/test/GetMatchCountVirtualDom.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@jest/globals'
+import { getMatchCountVirtualDom } from '../src/parts/GetMatchCountVirtualDom/GetMatchCountVirtualDom.ts'
+
+test('omits error attributes by default', () => {
+  const result = getMatchCountVirtualDom('1 match', 1, true)
+
+  expect(result[0]).not.toHaveProperty('id')
+  expect(result[0]).not.toHaveProperty('role')
+})

--- a/packages/find-widget-worker/test/Render2.test.ts
+++ b/packages/find-widget-worker/test/Render2.test.ts
@@ -14,3 +14,17 @@ test('render2 should return commands', () => {
   const result: readonly any[] = Render2.render2(uid, diffResult)
   expect(Array.isArray(result)).toBe(true)
 })
+
+test('renderInstance should return an empty result for an unknown instance', () => {
+  expect(Render2.renderInstance('unknown', [])).toEqual([])
+})
+
+test('renderInstance should render a registered instance', () => {
+  const uid = 2
+  const instanceId = 'editor:render:find'
+  const state = CreateDefaultState.createDefaultState()
+  FindWidgetStates.set(uid, state, state)
+  FindWidgetStates.registerInstance(instanceId, uid)
+
+  expect(Render2.renderInstance(instanceId, [])).toEqual([])
+})


### PR DESCRIPTION
Raises the Jest global branch coverage threshold to 97% and adds focused unit coverage for the previously uncovered find widget paths.